### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "federation-demo",
   "main": "gateway.js",
   "scripts": {
-    "start-gateway": "nodemon gateway.js",
+    "start-gateway": "nodemon --delay 1.5 gateway.js",
     "start-service-accounts": "nodemon services/accounts/index.js",
     "start-service-reviews": "nodemon services/reviews/index.js",
     "start-service-products": "nodemon services/products/index.js",


### PR DESCRIPTION
This delay is needed so that the services can spin back up (nodemon) before gateway attempts to.  Otherwise, gateway won't be able to find one of the services (every time)