### PR TITLE
Prep for Archival

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,7 @@
+# Archival
+This repo was archived by the Apollo Security team on 2023-05-26
+
+
 ## Apollo Federation Demo
 
 This repository is a demo of using Apollo Federation to build a single schema on top of multiple services. The microservices are located under the [`./services`](./services/) folder and the gateway that composes the overall schema is in the [`gateway.js`](./gateway.js) file.


### PR DESCRIPTION
This PR preps the repo for archival. It makes 2 changes if needed:
1. Updates readme with a note about archival
2. Defangs any CI config. This is done so that if the repo is ever restored, there are no surprise CI runs. To revert this change, rename the CI configuration folder back to its required name (`_github` -> `.github` OR `_circleci` -> `.circleci`) as appropriate.